### PR TITLE
Restructure and optimize `course_file` methods

### DIFF
--- a/classes/components/contentbank.php
+++ b/classes/components/contentbank.php
@@ -29,47 +29,44 @@ class contentbank extends course_file {
     /**
      * Show the name of the file as it appears in content bank
      *
-     * @param object $file
      * @return string
      * @throws \dml_exception
      */
-    protected function get_displayed_filename($file) {
+    protected function get_displayed_filename() : string {
         global $DB;
-        $cb = $DB->get_record('contentbank_content', ['id' => $file->itemid]);
+        $cb = $DB->get_record('contentbank_content', ['id' => $this->file->itemid]);
         return $cb->name;
     }
 
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        return $this->get_standard_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        return $this->get_standard_file_download_url();
     }
 
     /**
      * Try to get the url for the component (module or course).
      *
-     * @param object $file
      * @return null|\moodle_url
-     * @throws moodle_exception
+     * @throws \moodle_exception
      */
-    public function get_component_url($file) {
-        return new \moodle_url('/contentbank/index.php', ['contextid' => $file->contextid]);
+    protected function get_component_url() : ?\moodle_url {
+        return new \moodle_url('/contentbank/index.php', ['contextid' => $this->file->contextid]);
     }
 
     /**
      * Not checking content bank
      *
-     * @param object $file
      * @return null
+     * @throws \moodle_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         $fs = new \file_storage();
-        $f = new \stored_file($fs, $file);
-
+        $f = new \stored_file($fs, $this->file);
         return $fs->get_references_count_by_storedfile($f) > 1;
     }
 }

--- a/classes/components/mod_assign.php
+++ b/classes/components/mod_assign.php
@@ -29,56 +29,51 @@ class mod_assign extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        if ($file->filearea == 'introattachment') {
-            return $this->get_standard_file_download_url($file);
-        } else if ($file->filearea == 'intro') {
-            return $this->get_standard_file_download_url($file, false);
-        } else {
-            return parent::get_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        switch ($this->file->filearea) {
+            case 'introattachment':
+                return $this->get_standard_file_download_url();
+            case 'intro':
+                return $this->get_standard_file_download_url(false);
+            default:
+                return parent::get_file_download_url();
         }
-
     }
 
     /**
      * Creates the URL for the editor where the file is added
      *
-     * @param object $file
-     * @return \moodle_url|string
+     * @return \moodle_url|null
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    public function get_edit_url($file) {
+    protected function get_edit_url() : ?\moodle_url {
         global $DB;
-        $url = '';
-        if ($file->filearea === 'introattachment') {
-            $sql = 'SELECT cm.* FROM {context} ctx
-                        JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                        WHERE ctx.id = ?';
-            $mod = $DB->get_record_sql($sql, [$file->contextid]);
-            $url = new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
-        } else {
-            $url = parent::get_edit_url($file);
+        if ($this->file->filearea === 'introattachment') {
+            $sql = 'SELECT cm.*
+                      FROM {context} ctx
+                      JOIN {course_modules} cm ON cm.id = ctx.instanceid
+                     WHERE ctx.id = ?';
+            $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
+            return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
         }
-
-        return $url;
+        return parent::get_edit_url();
     }
 
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, introattachment.
-        if ($file->filearea === 'introattachment') {
+        if ($this->file->filearea === 'introattachment') {
             return true;
-        } else {
-            return parent::is_file_used($file);
         }
+        return parent::is_file_used();
     }
 }

--- a/classes/components/mod_assign.php
+++ b/classes/components/mod_assign.php
@@ -53,10 +53,10 @@ class mod_assign extends course_file {
     protected function get_edit_url() : ?\moodle_url {
         global $DB;
         if ($this->file->filearea === 'introattachment') {
-            $sql = 'SELECT cm.*
+            $sql = "SELECT cm.*
                       FROM {context} ctx
                       JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                     WHERE ctx.id = ?';
+                     WHERE ctx.id = ?";
             $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
             return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
         }

--- a/classes/components/mod_book.php
+++ b/classes/components/mod_book.php
@@ -29,53 +29,45 @@ class mod_book extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        if ($file->filearea == 'chapter') {
-            return $this->get_standard_file_download_url($file);
-        } else {
-            return parent::get_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        if ($this->file->filearea == 'chapter') {
+            return $this->get_standard_file_download_url();
         }
+        return parent::get_file_download_url();
     }
 
     /**
      * Creates the URL for the editor where the file is added
      *
-     * @param object $file
      * @return \moodle_url|null
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    public function get_edit_url($file) {
+    protected function get_edit_url() : ?\moodle_url {
         global $DB;
-        $url = null;
-        if ($file->filearea === 'chapter') { // Just checking description for now.
-            $ctx = $DB->get_record('context', ['id' => $file->contextid]);
-            $url = new \moodle_url('/mod/book/edit.php', ['cmid' => $ctx->instanceid, 'id' => $file->itemid]);
-        } else {
-            $url = parent::get_edit_url($file);
+        if ($this->file->filearea === 'chapter') { // Just checking description for now.
+            $ctx = $DB->get_record('context', ['id' => $this->file->contextid]);
+            return new \moodle_url('/mod/book/edit.php', ['cmid' => $ctx->instanceid, 'id' => $this->file->itemid]);
         }
-
-        return $url;
+        return parent::get_edit_url();
     }
 
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, chapter.
         global $DB;
-        if ($file->filearea === 'chapter') {
-            $chapter = $DB->get_record('book_chapters', ['id' => $file->itemid]);
-            $isused = $this->is_embedded_file_used($chapter, 'content', $file->filename);
-            return $isused;
-        } else {
-            return parent::is_file_used($file);
+        if ($this->file->filearea === 'chapter') {
+            $chapter = $DB->get_record('book_chapters', ['id' => $this->file->itemid]);
+            return $this->is_embedded_file_used($chapter, 'content', $this->file->filename);
         }
+        return parent::is_file_used();
     }
 }

--- a/classes/components/mod_data.php
+++ b/classes/components/mod_data.php
@@ -49,10 +49,10 @@ class mod_data extends course_file {
         // File areas = intro, content.
         global $DB;
         if ($this->file->filearea === 'content') {
-            $sql = 'SELECT *
+            $sql = "SELECT *
                       FROM {data_content} dc
                       JOIN {data_fields} df ON df.id = dc.fieldid
-                     WHERE dc.id = ?';
+                     WHERE dc.id = ?";
             $data = $DB->get_record_sql($sql, [$this->file->itemid]);
             $path = '@@PLUGINFILE@@/' . rawurlencode($this->file->filename);
             return $data->type !== 'textarea' || false !== strpos($data->content, $path);

--- a/classes/components/mod_data.php
+++ b/classes/components/mod_data.php
@@ -29,39 +29,34 @@ class mod_data extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        if ($file->filearea == 'content') {
-            return $this->get_standard_file_download_url($file);
-        } else {
-            return parent::get_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        if ($this->file->filearea == 'content') {
+            return $this->get_standard_file_download_url();
         }
+        return parent::get_file_download_url();
     }
 
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, content.
         global $DB;
-        if ($file->filearea === 'content') {
-            $sql = 'SELECT * FROM {data_content} dc
-                    JOIN {data_fields} df ON df.id = dc.fieldid
-                    WHERE dc.id = ?';
-            $data = $DB->get_record_sql($sql, [$file->itemid]);
-            if ($data->type !== 'textarea' ||
-                false !== strpos($data->content, '@@PLUGINFILE@@/' . rawurlencode($file->filename))) {
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            return parent::is_file_used($file);
+        if ($this->file->filearea === 'content') {
+            $sql = 'SELECT *
+                      FROM {data_content} dc
+                      JOIN {data_fields} df ON df.id = dc.fieldid
+                     WHERE dc.id = ?';
+            $data = $DB->get_record_sql($sql, [$this->file->itemid]);
+            $path = '@@PLUGINFILE@@/' . rawurlencode($this->file->filename);
+            return $data->type !== 'textarea' || false !== strpos($data->content, $path);
         }
+        return parent::is_file_used();
     }
 }

--- a/classes/components/mod_feedback.php
+++ b/classes/components/mod_feedback.php
@@ -54,10 +54,10 @@ class mod_feedback extends course_file {
         switch ($this->file->filearea) {
             case 'item':
             case 'page_after_submit':
-                $sql = 'SELECT cm.*
+                $sql = "SELECT cm.*
                           FROM {context} ctx
                           JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                         WHERE ctx.id = ?';
+                         WHERE ctx.id = ?";
                 $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
                 return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
             default:
@@ -79,11 +79,11 @@ class mod_feedback extends course_file {
                 $item = $DB->get_record('feedback_item', ['id' => $this->file->itemid]);
                 return $this->is_embedded_file_used($item, 'presentation', $this->file->filename);
             case 'page_after_submit':
-                $sql = 'SELECT m.*
+                $sql = "SELECT m.*
                           FROM {feedback} m
                           JOIN {course_modules} cm ON cm.instance = m.id
                           JOIN {context} ctx ON ctx.instanceid = cm.id
-                         WHERE ctx.id = ?';
+                         WHERE ctx.id = ?";
                 $feedback = $DB->get_record_sql($sql, [$this->file->contextid]);
                 return $this->is_embedded_file_used($feedback, 'page_after_submit', $this->file->filename);
             default:

--- a/classes/components/mod_folder.php
+++ b/classes/components/mod_folder.php
@@ -29,29 +29,27 @@ class mod_folder extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        if ($file->filearea === 'content') {
-            return $this->get_standard_file_download_url($file);
-        } else {
-            return parent::get_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        if ($this->file->filearea === 'content') {
+            return $this->get_standard_file_download_url();
         }
+        return parent::get_file_download_url();
     }
 
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, content.
-        if ($file->filearea === 'content') {
-                return true;
-        } else {
-            return parent::is_file_used($file);
+        if ($this->file->filearea === 'content') {
+            return true;
         }
+        return parent::is_file_used();
     }
 }

--- a/classes/components/mod_forum.php
+++ b/classes/components/mod_forum.php
@@ -29,33 +29,35 @@ class mod_forum extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        if ($file->filearea === 'post' || $file->filearea === 'attachment') {
-            return $this->get_standard_file_download_url($file);
-        } else {
-            return parent::get_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        switch ($this->file->filearea) {
+            case 'post':
+            case 'attachment':
+                return $this->get_standard_file_download_url();
+            default:
+                return parent::get_file_download_url();
         }
     }
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, post.
         global $DB;
-        if ($file->filearea === 'post') {
-            $post = $DB->get_record('forum_posts', ['id' => $file->itemid]);
-            $isused = $this->is_embedded_file_used($post, 'message', $file->filename);
-            return $isused;
-        } else if ($file->filearea === 'attachment') {
-            return true;
-        } else {
-            return parent::is_file_used($file);
+        switch ($this->file->filearea) {
+            case 'post':
+                $post = $DB->get_record('forum_posts', ['id' => $this->file->itemid]);
+                return $this->is_embedded_file_used($post, 'message', $this->file->filename);
+            case 'attachment':
+                return true;
+            default:
+                return parent::is_file_used();
         }
     }
 }

--- a/classes/components/mod_glossary.php
+++ b/classes/components/mod_glossary.php
@@ -29,34 +29,36 @@ class mod_glossary extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        if ($file->filearea === 'entry' || $file->filearea === 'attachment') {
-            return $this->get_standard_file_download_url($file);
-        } else {
-            return parent::get_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        switch ($this->file->filearea) {
+            case 'entry':
+            case 'attachment':
+                return $this->get_standard_file_download_url();
+            default:
+                return parent::get_file_download_url();
         }
     }
 
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, chapter.
         global $DB;
-        if ($file->filearea === 'attachment') {
-            return true;
-        } else if ($file->filearea === 'entry') {
-            $entry = $DB->get_record('glossary_entries', ['id' => $file->itemid]);
-            $isused = $this->is_embedded_file_used($entry, 'definition', $file->filename);
-            return $isused;
-        } else {
-            return parent::is_file_used($file);
+        switch ($this->file->filearea) {
+            case 'attachment':
+                return true;
+            case 'entry':
+                $entry = $DB->get_record('glossary_entries', ['id' => $this->file->itemid]);
+                return $this->is_embedded_file_used($entry, 'definition', $this->file->filename);
+            default:
+                return parent::is_file_used();
         }
     }
 }

--- a/classes/components/mod_h5pactivity.php
+++ b/classes/components/mod_h5pactivity.php
@@ -36,10 +36,10 @@ class mod_h5pactivity extends course_file {
     protected function get_edit_url() : ?\moodle_url {
         global $DB;
         if ($this->file->filearea === 'package') {
-            $sql = 'SELECT cm.*
+            $sql = "SELECT cm.*
                       FROM {context} ctx
                       JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                     WHERE ctx.id = ?';
+                     WHERE ctx.id = ?";
             $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
             return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
         }

--- a/classes/components/mod_h5pactivity.php
+++ b/classes/components/mod_h5pactivity.php
@@ -29,39 +29,34 @@ class mod_h5pactivity extends course_file {
     /**
      * Creates the URL for the editor where the file is added
      *
-     * @param object $file
      * @return \moodle_url|null
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    public function get_edit_url($file) {
+    protected function get_edit_url() : ?\moodle_url {
         global $DB;
-        $url = null;
-        if ($file->filearea === 'package') {
-            $sql = 'SELECT cm.* FROM {context} ctx
-                        JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                        WHERE ctx.id = ?';
-            $mod = $DB->get_record_sql($sql, [$file->contextid]);
-            $url = new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
-        } else {
-            $url = parent::get_edit_url($file);
+        if ($this->file->filearea === 'package') {
+            $sql = 'SELECT cm.*
+                      FROM {context} ctx
+                      JOIN {course_modules} cm ON cm.id = ctx.instanceid
+                     WHERE ctx.id = ?';
+            $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
+            return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
         }
-
-        return $url;
+        return parent::get_edit_url();
     }
 
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, package.
-        if ($file->filearea === 'package') {
+        if ($this->file->filearea === 'package') {
             return true;
-        } else {
-            return parent::is_file_used($file);
         }
+        return parent::is_file_used();
     }
 }

--- a/classes/components/mod_label.php
+++ b/classes/components/mod_label.php
@@ -44,10 +44,10 @@ class mod_label extends course_file {
      */
     protected function get_component_url() : ?\moodle_url {
         global $DB;
-        $sql = 'SELECT cm.*
+        $sql = "SELECT cm.*
                   FROM {context} ctx
                   JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                 WHERE ctx.id = ?';
+                 WHERE ctx.id = ?";
         $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
         return new \moodle_url('/course/view.php', ['id' => $mod->course, 'sectionid' => $mod->section]);
     }

--- a/classes/components/mod_label.php
+++ b/classes/components/mod_label.php
@@ -29,26 +29,26 @@ class mod_label extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        return $this->get_standard_file_download_url($file, false);
+    protected function get_file_download_url() : ?\moodle_url {
+        return $this->get_standard_file_download_url(false);
     }
 
     /**
      * Try to get the url for the component (module or course).
      *
-     * @param object $file
      * @return null|\moodle_url
-     * @throws moodle_exception
+     * @throws \moodle_exception
      */
-    public function get_component_url($file) {
+    protected function get_component_url() : ?\moodle_url {
         global $DB;
-        $sql = 'SELECT cm.* FROM {context} ctx
-                            JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                            WHERE ctx.id = ?';
-        $mod = $DB->get_record_sql($sql, [$file->contextid]);
+        $sql = 'SELECT cm.*
+                  FROM {context} ctx
+                  JOIN {course_modules} cm ON cm.id = ctx.instanceid
+                 WHERE ctx.id = ?';
+        $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
         return new \moodle_url('/course/view.php', ['id' => $mod->course, 'sectionid' => $mod->section]);
     }
 }

--- a/classes/components/mod_page.php
+++ b/classes/components/mod_page.php
@@ -49,10 +49,10 @@ class mod_page extends course_file {
     protected function get_edit_url() : ?\moodle_url {
         global $DB;
         if ($this->file->filearea === 'content') { // Just checking description for now.
-            $sql = 'SELECT cm.*
+            $sql = "SELECT cm.*
                       FROM {context} ctx
                       JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                     WHERE ctx.id = ?';
+                     WHERE ctx.id = ?";
             $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
             return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
         }
@@ -69,11 +69,11 @@ class mod_page extends course_file {
         // File areas = intro, content.
         global $DB;
         if ($this->file->filearea === 'content') {
-            $sql = 'SELECT m.*
+            $sql = "SELECT m.*
                       FROM {page} m
                       JOIN {course_modules} cm ON cm.instance = m.id
                       JOIN {context} ctx ON ctx.instanceid = cm.id
-                     WHERE ctx.id = ?';
+                     WHERE ctx.id = ?";
             $page = $DB->get_record_sql($sql, [$this->file->contextid]);
             return $this->is_embedded_file_used($page, 'content', $this->file->filename);
         }

--- a/classes/components/mod_page.php
+++ b/classes/components/mod_page.php
@@ -29,60 +29,54 @@ class mod_page extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        if ($file->filearea === 'content') {
-            return $this->get_standard_file_download_url($file);
-        } else {
-            return parent::get_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        if ($this->file->filearea === 'content') {
+            return $this->get_standard_file_download_url();
         }
+        return parent::get_file_download_url();
     }
 
     /**
      * Creates the URL for the editor where the file is added
      *
-     * @param object $file
      * @return \moodle_url|null
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    public function get_edit_url($file) {
+    protected function get_edit_url() : ?\moodle_url {
         global $DB;
-        $url = null;
-        if ($file->filearea === 'content') { // Just checking description for now.
-            $sql = 'SELECT cm.* FROM {context} ctx
-                        JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                        WHERE ctx.id = ?';
-            $mod = $DB->get_record_sql($sql, [$file->contextid]);
-            $url = new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
-        } else {
-            $url = parent::get_edit_url($file);
+        if ($this->file->filearea === 'content') { // Just checking description for now.
+            $sql = 'SELECT cm.*
+                      FROM {context} ctx
+                      JOIN {course_modules} cm ON cm.id = ctx.instanceid
+                     WHERE ctx.id = ?';
+            $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
+            return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
         }
-
-        return $url;
+        return parent::get_edit_url();
     }
 
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, content.
         global $DB;
-        if ($file->filearea === 'content') {
-            $sql = 'SELECT m.* FROM {page} m
-                    JOIN {course_modules} cm ON cm.instance = m.id
-                    JOIN {context} ctx ON ctx.instanceid = cm.id
-                    WHERE ctx.id = ?';
-            $page = $DB->get_record_sql($sql, [$file->contextid]);
-            $isused = $this->is_embedded_file_used($page, 'content', $file->filename);
-            return $isused;
-        } else {
-            return parent::is_file_used($file);
+        if ($this->file->filearea === 'content') {
+            $sql = 'SELECT m.*
+                      FROM {page} m
+                      JOIN {course_modules} cm ON cm.instance = m.id
+                      JOIN {context} ctx ON ctx.instanceid = cm.id
+                     WHERE ctx.id = ?';
+            $page = $DB->get_record_sql($sql, [$this->file->contextid]);
+            return $this->is_embedded_file_used($page, 'content', $this->file->filename);
         }
+        return parent::is_file_used();
     }
 }

--- a/classes/components/mod_resource.php
+++ b/classes/components/mod_resource.php
@@ -29,53 +29,47 @@ class mod_resource extends course_file {
     /**
      * Try to get the download url for a file.
      *
-     * @param object $file
      * @return null|\moodle_url
+     * @throws \moodle_exception
      */
-    public function get_file_download_url($file) {
-        if ($file->filearea === 'content') {
-            return $this->get_standard_file_download_url($file);
-        } else {
-            return parent::get_file_download_url($file);
+    protected function get_file_download_url() : ?\moodle_url {
+        if ($this->file->filearea === 'content') {
+            return $this->get_standard_file_download_url();
         }
+        return parent::get_file_download_url();
     }
 
     /**
      * Creates the URL for the editor where the file is added
      *
-     * @param object $file
      * @return \moodle_url|null
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    public function get_edit_url($file) {
+    protected function get_edit_url() : ?\moodle_url {
         global $DB;
-        $url = null;
-        if ($file->filearea === 'content') {
-            $sql = 'SELECT cm.* FROM {context} ctx
-                        JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                        WHERE ctx.id = ?';
-            $mod = $DB->get_record_sql($sql, [$file->contextid]);
-            $url = new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
-        } else {
-            $url = parent::get_edit_url($file);
+        if ($this->file->filearea === 'content') {
+            $sql = 'SELECT cm.*
+                      FROM {context} ctx
+                      JOIN {course_modules} cm ON cm.id = ctx.instanceid
+                     WHERE ctx.id = ?';
+            $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
+            return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
         }
-
-        return $url;
+        return parent::get_edit_url();
     }
 
     /**
      * Checks if embedded files have been used
      *
-     * @param object $file
-     * @return bool
+     * @return bool|null
+     * @throws \dml_exception
      */
-    public function is_file_used($file) {
+    protected function is_file_used() : ?bool {
         // File areas = intro, chapter.
-        if ($file->filearea === 'content') {
+        if ($this->file->filearea === 'content') {
             return true;
-        } else {
-            return parent::is_file_used($file);
         }
+        return parent::is_file_used();
     }
 }

--- a/classes/components/mod_resource.php
+++ b/classes/components/mod_resource.php
@@ -49,10 +49,10 @@ class mod_resource extends course_file {
     protected function get_edit_url() : ?\moodle_url {
         global $DB;
         if ($this->file->filearea === 'content') {
-            $sql = 'SELECT cm.*
+            $sql = "SELECT cm.*
                       FROM {context} ctx
                       JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                     WHERE ctx.id = ?';
+                     WHERE ctx.id = ?";
             $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
             return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
         }

--- a/classes/course_file.php
+++ b/classes/course_file.php
@@ -16,6 +16,8 @@
 
 namespace local_listcoursefiles;
 
+use Matrix\Exception;
+
 /**
  * Class course_file
  * @package local_listcoursefiles
@@ -245,11 +247,14 @@ class course_file {
         switch ($component) {
             case 'mod': // Course module.
                 $modname = str_replace('mod_', '', $this->file->component);
+                if (!array_key_exists($modname, \core_component::get_plugin_list('mod'))) {
+                    return null;
+                }
                 if ($this->file->filearea === 'intro') {
                     $sql = "SELECT m.*
                               FROM {context} ctx
                               JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                              JOIN {$modname} m ON m.id = cm.instance
+                              JOIN {{$modname}} m ON m.id = cm.instance
                              WHERE ctx.id = ?";
                     $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
                     return $this->is_embedded_file_used($mod, 'intro', $this->file->filename);

--- a/classes/course_file.php
+++ b/classes/course_file.php
@@ -16,8 +16,6 @@
 
 namespace local_listcoursefiles;
 
-use Matrix\Exception;
-
 /**
  * Class course_file
  * @package local_listcoursefiles
@@ -97,6 +95,21 @@ class course_file {
      */
     public $fileused;
 
+    /**
+     * Creates an object of this class or an appropriate subclass.
+     * @param \stdClass $file
+     * @return course_file
+     * @throws \coding_exception
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public static function create(\stdClass $file) : course_file {
+        $classname = '\local_listcoursefiles\components\\' . $file->component;
+        if (class_exists($classname)) {
+            return new $classname($file);
+        }
+        return new course_file($file);
+    }
 
     /**
      * course_file constructor.
@@ -273,12 +286,12 @@ class course_file {
     /**
      * Test if a file is embedded in text
      *
-     * @param object $record
+     * @param \stdClass|false $record
      * @param string $field
      * @param string $filename
      * @return bool|null
      */
-    protected function is_embedded_file_used(object $record, string $field, string $filename) : ?bool {
+    protected function is_embedded_file_used($record, string $field, string $filename) : ?bool {
         if ($record && property_exists($record, $field)) {
             return is_int(strpos($record->$field, '@@PLUGINFILE@@/' . rawurlencode($filename)));
         }
@@ -298,10 +311,10 @@ class course_file {
         switch ($component) {
             case 'mod':
                 if ($this->file->filearea === 'intro') { // Just checking description for now.
-                    $sql = 'SELECT cm.*
+                    $sql = "SELECT cm.*
                               FROM {context} ctx
                               JOIN {course_modules} cm ON cm.id = ctx.instanceid
-                             WHERE ctx.id = ?';
+                             WHERE ctx.id = ?";
                     $mod = $DB->get_record_sql($sql, [$this->file->contextid]);
                     return new \moodle_url('/course/modedit.php?', ['update' => $mod->id]);
                 }


### PR DESCRIPTION
In the `course_file` base class, assign the `$file` as a protected property early on during initialization. Then there is no need to pass it around every method.

Make all methods of the `course_file` sub-classes protected.

Ensure consistent PHPDoc parameters throughout `course_file` and its sub-classes.

Optimize and/or simplify some control flows here and there.