### PR TITLE
Use `license_manager::get_active_licenses` (fixes #8)

### DIFF
--- a/classes/course_file.php
+++ b/classes/course_file.php
@@ -122,7 +122,7 @@ class course_file {
         global $COURSE;
         $this->courseid = $COURSE->id;
         $this->file = $file;
-        $this->filelicense = licences::get_license_name_color($file->license);
+        $this->filelicense = licences::get_license_name_color($file->license ?? '');
         $this->fileid = $file->id;
         $this->filesize = display_size($file->filesize);
         $this->filetype = mimetypes::get_file_type_translation($file->mimetype);


### PR DESCRIPTION
See #8.

A few additional changes:
- Update/expand documentation, fix typos
- Declare missing types, make existing declarations more specific
- Use imports
- Slightly optimize `licenses` methods